### PR TITLE
Fix example, update to ash 0.32.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-ash = "0.31.0"
+ash = "0.32.1"
 bytemuck = "1.5.0"
 copypasta = "0.7.1"
 egui = "0.10.0"
@@ -28,7 +28,7 @@ winit = "0.24.0"
 
 [dev-dependencies]
 anyhow = "1.0.38"
-ash-window = "0.5.0"
+ash-window = "0.6.0"
 crevice = "0.6.0"
 image = "0.23.13"
 memoffset = "0.6.1"

--- a/examples/example/main.rs
+++ b/examples/example/main.rs
@@ -207,7 +207,7 @@ impl App {
             .build(event_loop)?;
 
         // Create Entry
-        let entry = Entry::new()?;
+        let entry = unsafe { Entry::new() }?;
 
         // Create Instance
         let instance = {


### PR DESCRIPTION
Current main does not compile or run due to errors with mismatched ash versions in vk-mem-rs, ash-window and this project. I updated the toml and made one small change to get it to compile. 